### PR TITLE
Also run envoy utests

### DIFF
--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -12,9 +12,17 @@ build --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 build --test_env=HEAPCHECK=minimal
 build --test_output=all
 
-# As of today we do not support QUIC/HTTP3 -- hence we exclude it from the build, always.
-build --deleted_packages=@envoy//test/common/quic,@envoy//test/common/quic/platform
-build --@envoy//bazel:http3=false
+# As of today we do not support QUIC/HTTP3, hence we exclude it from the build, always.
+# Unfortunately, just setting //bazel:http3=False, is not enough to achieve this.
+# Instead, we also have to use boringssl=fips define and filter on the nofips tag.
+# This is based on the fact that the FIPS version of BoringSSL doesn't provide enough
+# of the functions required to build the QUIC implementation provided by Quiche i.e. if
+# we say that we are using the FIPS version of BoringSSL, then all the QUIC support is
+# excluded from the build.
+common --@envoy//bazel:http3=False
+common --define=boringssl=fips
+build --build_tag_filters=-nofips
+test --test_tag_filters=-nofips
 
 # Arch-specific build flags, triggered with --config=$ARCH in bazel build command
 build:x86_64 --linkopt=-fuse-ld=lld

--- a/maistra/ci/pre-submit.sh
+++ b/maistra/ci/pre-submit.sh
@@ -15,6 +15,9 @@ time bazel_build //:envoy
 echo "Build succeeded. Binary generated:"
 bazel-bin/envoy --version
 
+# Run envoy tests
+time bazel_test @envoy//test/...
+
 # Run tests
 time bazel_test //...
 


### PR DESCRIPTION
This PR adds a run of the `@envoy//test/...` unit tests to the proxy pre-submit checks.

Without this, we are currently not running any of envoy's utests at any point, because we
do not yet have any build & test on the upstream `envoyproxy/envoy-openssl` repository.