### PR TITLE
Update bazelrc parameter for s390x

### DIFF
--- a/maistra/bazelrc
+++ b/maistra/bazelrc
@@ -18,7 +18,7 @@ build --@envoy//bazel:http3=false
 
 # Arch-specific build flags, triggered with --config=$ARCH in bazel build command
 build:x86_64 --linkopt=-fuse-ld=lld
-build:s390x --@envoy//source/extensions/filters/common/lua:luajit2=1 --cxxopt='-includeoptional' --copt=-Wno-error=type-limits --copt=-Wno-error=uninitialized --linkopt=-fuse-ld=gold --copt=-fno-builtin-strlen
+build:s390x --@envoy//source/extensions/filters/common/lua:luajit2=1 --cxxopt='-includeoptional' --copt=-Wno-error=type-limits --copt=-Wno-error=uninitialized --linkopt=-fuse-ld=gold --copt=-fno-builtin-strlen --action_env=BAZEL_LINKLIBS=-lstdc++
 build:ppc --linkopt=-fuse-ld=lld --@envoy//source/extensions/filters/common/lua:luajit2=1
 build:aarch64 --linkopt=-fuse-ld=lld
 


### PR DESCRIPTION
Added --action_env=BAZEL_LINKLIBS=-lstdc++ parameter to dynamically link libstdc++ library to build on s390x.

**What this PR does / why we need it**: Fix envoy build issue on s390x
