### PR TITLE
fix: don't overwrite the status if no additional validation was done

### DIFF
--- a/maistra/vendor/envoy/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/maistra/vendor/envoy/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -248,7 +248,7 @@ int DefaultCertValidator::doSynchronousVerifyCertChain(
       Envoy::Ssl::ClientValidationStatus::NotValidated;
   bool success = verifyCertAndUpdateStatus(&leaf_cert, transport_socket_options, detailed_status,
                                            nullptr, nullptr);
-  if (ssl_extended_info) {
+  if (ssl_extended_info && detailed_status != Envoy::Ssl::ClientValidationStatus::NotValidated) {
     ssl_extended_info->setCertificateValidationStatus(detailed_status);
   }
   if (!success) {


### PR DESCRIPTION
There are 2 sets of certificate validation that happens, the first one is successful but then the additional validation is skipped but we overwrite the status of the first validation marking it as NotValidated.

**What this PR does / why we need it**:
It prevents overwriting of  the status of the first certificate validation if additional validation was skipped

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://issues.redhat.com/browse/AAP-42203

**Special notes for your reviewer**:
